### PR TITLE
fix(package.install): proper package for CentOS and Rocky Linux 8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,24 +17,23 @@ repos:
         stages: [manual]
         additional_dependencies: ['@commitlint/config-conventional@8.3.4']
         always_run: true
-  - repo: https://github.com/adithyabsk/mirrors-rubocop
-    rev: v0.91.0
+  - repo: https://github.com/rubocop-hq/rubocop
+    rev: v1.25.1
     hooks:
       - id: rubocop
         name: Check Ruby files with rubocop
         args: [--debug]
         always_run: true
         pass_filenames: false
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.3
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.8.0.4
     hooks:
       - id: shellcheck
         name: Check shell scripts with shellcheck
         files: ^.*\.(sh|bash|ksh)$
         types: []
-        args: []
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.23.0
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.26.3
     hooks:
       - id: yamllint
         name: Check YAML syntax with yamllint
@@ -42,7 +41,7 @@ repos:
         always_run: true
         pass_filenames: false
   - repo: https://github.com/warpnet/salt-lint
-    rev: v0.3.0
+    rev: v0.8.0
     hooks:
       - id: salt-lint
         name: Check Salt files using salt-lint
@@ -53,4 +52,16 @@ repos:
       - id: rstcheck
         name: Check reST files using rstcheck
         exclude: 'docs/CHANGELOG.rst'
-        args: [--report=warning]
+  - repo: https://github.com/saltstack-formulas/mirrors-rst-lint
+    rev: v1.3.2
+    hooks:
+      - id: rst-lint
+        name: Check reST files using rst-lint
+        exclude: |
+            (?x)^(
+                docs/CHANGELOG.rst|
+                docs/TOFS_pattern.rst|
+                docs/CONTRIBUTING_DOCS.rst|
+                docs/index.rst|
+            )$
+        additional_dependencies: [pygments==2.9.0]

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,7 +1,7 @@
 .. _readme:
 
 wireguard-formula
-================
+=================
 
 |img_travis| |img_sr| |img_pc|
 
@@ -73,7 +73,7 @@ Available states
    :local:
 
 ``wireguard``
-^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 *Meta-state (This is a state that includes other states)*.
 
@@ -82,24 +82,24 @@ manages the wireguard configuration file and then
 starts the associated wireguard service.
 
 ``wireguard.package``
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 This state will install the wireguard package only.
 
 ``wireguard.config``
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 This state will configure the wireguard service and has a dependency on ``wireguard.install``
 via include list.
 
 ``wireguard.service``
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 This state will start the wireguard service and has a dependency on ``wireguard.config``
 via include list.
 
 ``wireguard.clean``
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 *Meta-state (This is a state that includes other states)*.
 
@@ -109,18 +109,18 @@ removes the configuration file and
 then uninstalls the package.
 
 ``wireguard.service.clean``
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This state will stop the wireguard service and disable it at boot time.
 
 ``wireguard.config.clean``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This state will remove the configuration of the wireguard service and has a
 dependency on ``wireguard.service.clean`` via include list.
 
 ``wireguard.package.clean``
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This state will remove the wireguard package and has a depency on
 ``wireguard.config.clean`` via include list.

--- a/wireguard/defaults.yaml
+++ b/wireguard/defaults.yaml
@@ -4,6 +4,8 @@
 wireguard:
   pkg:
     name: wireguard
+    pkgs: {}
+    repos: {}
   rootgroup: root
   config: '/etc/wireguard'
   service:

--- a/wireguard/osfingermap.yaml
+++ b/wireguard/osfingermap.yaml
@@ -24,12 +24,62 @@ Fedora-31: {}
 Fedora-30: {}
 
 # os: CentOS
-CentOS Linux-8: {}
+CentOS Linux-8:
+  service:
+    name: wg-quick
+  pkg:
+    repos:
+      epel:
+        humanname: Extra Packages for Enterprise Linux 8 - $basearch
+        mirrorlist: |-
+          https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&
+          infra=$infra&content=$contentdir
+        enabled: 1
+        gpgcheck: 1
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8
+      elrepo:
+        humanname: ELRepo.org Community Enterprise Linux Repository - el8
+        mirrorlist: http://mirrors.elrepo.org/mirrors-elrepo.el8
+        enabled: 1
+        gpgcheck: 1
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
+    pkgs:
+      wireguard-tools:
+        fromrepo: epel
+      kmod-wireguard:
+        fromrepo: elrepo
+
 CentOS Linux-7: {}
 CentOS-6:
   pkg:
     name: wireguard-centos-6
   config: /etc/wireguard.d/custom-centos-6.conf
+
+# os: Rocky
+Rocky Linux-8:
+  service:
+    name: wg-quick
+  pkg:
+    repos:
+      epel:
+        humanname: Extra Packages for Enterprise Linux 8 - $basearch
+        mirrorlist: |-
+          https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&
+          infra=$infra&content=$contentdir
+        enabled: 1
+        gpgcheck: 1
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8
+      elrepo:
+        humanname: ELRepo.org Community Enterprise Linux Repository - el8
+        mirrorlist: http://mirrors.elrepo.org/mirrors-elrepo.el8
+        enabled: 1
+        gpgcheck: 1
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
+    pkgs:
+      wireguard-tools:
+        fromrepo: epel
+      kmod-wireguard:
+        fromrepo: elrepo
 
 # os: Amazon
 Amazon Linux-2: {}

--- a/wireguard/package/install.sls
+++ b/wireguard/package/install.sls
@@ -5,6 +5,32 @@
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import wireguard with context %}
 
+{%- for repo_name, repo in wireguard.pkg.repos.items() %}
+wireguard-package-install-repo-{{ repo_name }}:
+  pkgrepo.managed:
+    - name: {{ repo_name }}
+    {%- for key, value in repo.items() %}
+      {%- if value is string %}
+    - {{ key }}: {{ value | replace('\n', '') }}
+      {%- else %}
+    - {{ key }}: {{ value }}
+      {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+
+{%- if wireguard.pkg.pkgs|length > 0 %}
+  {%- for pkg_name, pkg in wireguard.pkg.pkgs.items() %}
+wireguard-package-install-pkg-{{ pkg_name }}-installed:
+  pkg.installed:
+    - name: {{ pkg_name }}
+    {%- if pkg.fromrepo is defined %}
+    - fromrepo: {{ pkg.fromrepo }}
+    - require:
+      - pkgrepo: wireguard-package-install-repo-{{ pkg.fromrepo }}
+    {%- endif %}
+  {%- endfor %}
+{%- else %}
 wireguard-package-install-pkg-installed:
   pkg.installed:
     - name: {{ wireguard.pkg.name }}
+{%- endif %}


### PR DESCRIPTION
fixes #3

Squashed commit of the following:

commit f07bf84dd6421a596d4cdbf8ab9e33f1465a56eb
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 19:06:29 2022 +0200

    fix(osfingermap): support CentOS 8

commit 7220f6763b354f7f82bf062ef7f1e47bb7961b0d
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:56:59 2022 +0200

    fix(osfingermap): set service name to wg-quick for Rocky Linux 8

commit aeb7ac76829a6896cc6acf0cb79b4eeda32483ac
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:48:57 2022 +0200

    fix(package.install): set name to pkgrepo state call

commit 311851afa2ee5b0b75c91ca625daaa4021704c08
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:44:47 2022 +0200

    fix(package.install): indent wireguard-package-install-pkg-{{ pkg_name }} correctly

commit 2793a106eba87edf137e5004260529e2289e7255
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:41:38 2022 +0200

    fix(package.install): resolve conflicting state ID

commit 59d99821d4c7c36bec767e6e5b7af23eb63f7c1e
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:40:20 2022 +0200

    fix(package.install): iterate over all pkgs instead

commit 773e53a42222c04d4c152b35cc9917cbbd515546
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:37:18 2022 +0200

    fix(package.install): support CentOS and Rocky Linux 8

commit 6e0d3288fbc2815730d7ceda3ce0f1dab28bc25e
Author: Ewout van Mansom <ewout@vanmansom.name>
Date:   Fri May 20 18:36:19 2022 +0200

    chore(precommit): update